### PR TITLE
Fixed bug

### DIFF
--- a/WikipediaReferences/Controllers/NYTimesController.cs
+++ b/WikipediaReferences/Controllers/NYTimesController.cs
@@ -113,6 +113,9 @@ namespace WikipediaReferences.Controllers
             if (updateDeathDateDto == null)
                 return BadRequest("Dto object cannot be null.");
 
+            if (string.IsNullOrEmpty(updateDeathDateDto.ArticleTitle))
+                return BadRequest("articleTitle cannot be null or empty.");
+
             IEnumerable<Models.Reference> references = nyTimesService.GetReferencesByArticleTitle(updateDeathDateDto.ArticleTitle);
 
             if (!references.Any())


### PR DESCRIPTION
This bug wouldn't have been catastrophic when passing an empy article title if it wasn't for the fact that in the previous PR determining the references was changed as well:
return context.References.Where(r => r.SourceCode == "NYT" && r.ArticleTitle.StartsWith(articleTitle));

StartsWith resulted in updating ALL records when passing an empty article title :('